### PR TITLE
import /usr/include instead of macosx sdk

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -5,6 +5,7 @@ set -e
 root_dir=$(pwd)
 
 mkdir -p build/SwishUtils && (cd ./build/SwishUtils && swiftc \
+  -I /usr/include \
   -emit-library -module-name SwishUtils -emit-module \
   -Xlinker -install_name -Xlinker "@rpath/libSwishUtils.dylib" \
   $(find $root_dir/src/swish/utils -name *.swift))
@@ -12,6 +13,7 @@ mkdir -p build/SwishUtils && (cd ./build/SwishUtils && swiftc \
 echo "built utils"
 
 mkdir -p build/Swish && (cd ./build/Swish && swiftc \
+  -I /usr/include \
   -L$root_dir/build/SwishUtils -I$root_dir/build/SwishUtils -lSwishUtils \
   -emit-library -module-name Swish -emit-module \
   -Xlinker -install_name -Xlinker "@rpath/libSwish.dylib" \
@@ -20,6 +22,7 @@ mkdir -p build/Swish && (cd ./build/Swish && swiftc \
 echo "built core"
 
 mkdir -p build/SwishBuildSwift && (cd ./build/SwishBuildSwift && swiftc \
+  -I /usr/include \
   -L$root_dir/build/Swish -I$root_dir/build/Swish -lSwish \
   -L$root_dir/build/SwishUtils -I$root_dir/build/SwishUtils -lSwishUtils \
   -emit-library -module-name SwishBuildSwift -emit-module \
@@ -29,6 +32,7 @@ mkdir -p build/SwishBuildSwift && (cd ./build/SwishBuildSwift && swiftc \
 echo "built swift-builder"
 
 mkdir -p build/SwishProjects && (cd ./build/SwishProjects && swiftc \
+  -I /usr/include \
   -L$root_dir/build/SwishBuildSwift -I$root_dir/build/SwishBuildSwift -lSwishBuildSwift \
   -L$root_dir/build/Swish -I$root_dir/build/Swish -lSwish \
   -L$root_dir/build/SwishUtils -I$root_dir/build/SwishUtils -lSwishUtils \

--- a/bin/swish
+++ b/bin/swish
@@ -14,7 +14,8 @@ fi
 if [[ -f project.swift ]]; then
   mkdir -p build/project
 
-  xcrun swiftc \
+  swiftc \
+    -I /usr/include \
     -I $(pwd)/.swish/lib \
     -L $(pwd)/.swish/lib \
     -Xlinker -rpath -Xlinker $(pwd)/.swish/lib \

--- a/bin/swish-example
+++ b/bin/swish-example
@@ -13,7 +13,8 @@ fi
 
 (mkdir -p example/build/project)
 
-(cd ./example && xcrun swiftc \
+(cd ./example && swiftc \
+  -I /usr/include
   -I $(pwd)/.swish/lib \
   -L $(pwd)/.swish/lib \
   -Xlinker -rpath -Xlinker $(pwd)/.swish/lib \

--- a/src/swish/build/swift/SwiftTargetBuild.swift
+++ b/src/swish/build/swift/SwiftTargetBuild.swift
@@ -55,7 +55,8 @@ public struct SwiftTargetBuild {
 
 	public var cmd: String {
 		return [
-			["(cd ./\(target.buildDir) &&", "xcrun", "-sdk \(sdk)", "swiftc"],
+			["(cd ./\(target.buildDir) &&", "swiftc"],
+			["-I/usr/include"],
 			linkPaths,
 			importPaths,
 			linkModules,


### PR DESCRIPTION
Instead of depending on `xcrun -sdk (whateversdk)`  import the dependencies (like `Darwin`) instead.